### PR TITLE
In removeTween(), check that _activeTweens contains tween to be removed.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@
 *.csproj
 *.unityproj
 *.sln
+*.pidb
 Xcode
 GoKitLite.userprefs

--- a/Assets/Plugins/GoKitLite/GoKitLite.cs
+++ b/Assets/Plugins/GoKitLite/GoKitLite.cs
@@ -350,9 +350,13 @@ public partial class GoKitLite : MonoBehaviour
 
 	private void removeTween( Tween tween, int index )
 	{
-		_activeTweens.RemoveAt( index );
-		tween.reset();
-		_inactiveTweenStack.Push( tween );
+        if ( _activeTweens.Contains( tween ) )
+        {
+            _activeTweens.RemoveAt( index );
+
+            tween.reset();
+            _inactiveTweenStack.Push( tween );
+        }
 	}
 	
 	#endregion


### PR DESCRIPTION
Calling removeAllTweens() or stopTween() in an onComplete function will cause the
tween to be removed from the _activeTweens list.  When removeTween() is then called in the GoKitLite Update() function, that tween is no longer in the list and  _activeTweens.RemoveAt() will throw an exception.
