### PR TITLE
Comparison of floating point numbers can be unequal

### DIFF
--- a/Assets/GoKitLite/GoKitLite.cs
+++ b/Assets/GoKitLite/GoKitLite.cs
@@ -212,10 +212,10 @@ namespace Prime31.GoKitLite
 				}
 
 				// if we have a loopType and we are done do the loop
-				if( loopType != GoKitLite.LoopType.None && _elapsedTime == duration )
+				if( loopType != GoKitLite.LoopType.None &&  Mathf.Approximately(_elapsedTime, duration) )
 					handleLooping();
 
-				return _elapsedTime == duration;
+				return Mathf.Approximately(_elapsedTime, duration);
 			}
 
 


### PR DESCRIPTION
Comparison of floating point numbers can be unequal due to the differing precision of the two values.