### PR TITLE
Easing.Elastic class is recommended to be defined as static

### DIFF
--- a/Assets/GoKitLite/GoKitLiteEasing.cs
+++ b/Assets/GoKitLite/GoKitLiteEasing.cs
@@ -158,7 +158,7 @@ namespace Prime31.GoKitLite
         }
 
 
-        public class Elastic
+        public static class Elastic
         {
             public static float EaseIn(float t, float d)
             {


### PR DESCRIPTION
All  defined classes under static "Easing" class are defined as static except "Elastic" class.